### PR TITLE
Missing outputFolder to deployService in k8s-helper

### DIFF
--- a/tools/k8s-helper.sh
+++ b/tools/k8s-helper.sh
@@ -97,6 +97,11 @@ function fetchAndSourceScripts() {
 		source "${SCRIPTS}"/src/main/bash/pipeline-k8s.sh
 
 		# Overridden functions
+		function outputFolder() {
+			echo "${FOLDER}build"
+		}
+		export -f outputFolder			
+		
 		function mySqlDatabase() {
 			echo "github"
 		}


### PR DESCRIPTION
Executing `k8s-helper setup-prod-infra` ----------> error: outputFolder command not found.