### PR TITLE
URL Cleanup

### DIFF
--- a/declarative-pipeline/build.gradle
+++ b/declarative-pipeline/build.gradle
@@ -19,10 +19,10 @@ sourceSets {
 repositories {
 	jcenter()
 	mavenCentral()
-	maven { url 'http://repo.jenkins-ci.org/releases/' }
-	maven { url "http://repo.spring.io/libs-snapshot-local" }
-	maven { url "http://repo.spring.io/libs-milestone-local" }
-	maven { url "http://repo.spring.io/libs-release-local" }
+	maven { url 'https://repo.jenkins-ci.org/releases/' }
+	maven { url "https://repo.spring.io/libs-snapshot-local" }
+	maven { url "https://repo.spring.io/libs-milestone-local" }
+	maven { url "https://repo.spring.io/libs-release-local" }
 }
 
 configurations {

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && \
 
 # Install cf-cli
 RUN curl -sL https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - && \
-    echo "deb http://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
+    echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends cf-cli && \
     apt-get clean && \
@@ -88,7 +88,7 @@ RUN echo "deb https://apt.dockerproject.org/repo debian-jessie main" | tee /etc/
 # You can use Jenkins API to generate the list of plugins from a running
 # Jenkins instance:
 #
-#  $ JENKINS_URL="http://user:pass@localhost:8080"
+#  $ JENKINS_URL="https://user:pass@localhost:8080"
 #  $ curl -sSL "${JENKINS_URL}/pluginManager/api/json?depth=1" | \
 #    jq -r '.plugins[] | .shortName +":"+ .version' | sort > plugins.txt
 #

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -11,10 +11,10 @@ sourceSets {
 repositories {
 	jcenter()
 	mavenCentral()
-	maven { url 'http://repo.jenkins-ci.org/releases/' }
-	maven { url "http://repo.spring.io/libs-snapshot-local" }
-	maven { url "http://repo.spring.io/libs-milestone-local" }
-	maven { url "http://repo.spring.io/libs-release-local" }
+	maven { url 'https://repo.jenkins-ci.org/releases/' }
+	maven { url "https://repo.spring.io/libs-snapshot-local" }
+	maven { url "https://repo.spring.io/libs-milestone-local" }
+	maven { url "https://repo.spring.io/libs-release-local" }
 }
 
 dependencies {

--- a/job-dsl/build.gradle
+++ b/job-dsl/build.gradle
@@ -25,10 +25,10 @@ ext {
 repositories {
 	jcenter()
 	mavenCentral()
-	maven { url 'http://repo.jenkins-ci.org/releases/' }
-	maven { url "http://repo.spring.io/libs-snapshot-local" }
-	maven { url "http://repo.spring.io/libs-milestone-local" }
-	maven { url "http://repo.spring.io/libs-release-local" }
+	maven { url 'https://repo.jenkins-ci.org/releases/' }
+	maven { url "https://repo.spring.io/libs-snapshot-local" }
+	maven { url "https://repo.spring.io/libs-milestone-local" }
+	maven { url "https://repo.spring.io/libs-release-local" }
 }
 
 configurations {

--- a/tools/cf-helper.sh
+++ b/tools/cf-helper.sh
@@ -34,7 +34,7 @@ CF_DEFAULT_ORG="${CF_DEFAULT_ORG:-pcfdev-org}"
 export CF_DEFAULT_SPACE
 CF_DEFAULT_SPACE="${CF_DEFAULT_SPACE:-cloudpipelines-test}"
 export ARTIFACTORY_URL
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://repo.spring.io/libs-milestone}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://repo.spring.io/libs-milestone}"
 export EUREKA_MEMORY
 EUREKA_MEMORY="${EUREKA_MEMORY:-1024m}"
 

--- a/tools/deploy-infra.sh
+++ b/tools/deploy-infra.sh
@@ -7,7 +7,7 @@
 # Examples:
 #   $ ./tools/deploy-infra.sh
 #   $ ./tools/deploy-infra.sh ../repos/pivotal/
-#   $ ARTIFACTORY_URL="http://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
+#   $ ARTIFACTORY_URL="https://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
 #
 
 set -o errexit
@@ -23,7 +23,7 @@ if [[ -z "${POTENTIAL_DOCKER_HOST}" ]]; then
     POTENTIAL_DOCKER_HOST="localhost"
 fi
 
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
 ARTIFACTORY_ID="${ARTIFACTORY_ID:-artifactory-local}"
 
 function deploy_project {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.catosplace.net/blog/2015/02/11/running-jenkins-in-docker-containers/ (200) could not be migrated:  
   ([https](https://www.catosplace.net/blog/2015/02/11/running-jenkins-in-docker-containers/) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://192.168.99.100:8081/artifactory/libs-release-local (ConnectTimeoutException) migrated to:  
  https://192.168.99.100:8081/artifactory/libs-release-local ([https](https://192.168.99.100:8081/artifactory/libs-release-local) result ConnectTimeoutException).
* http://admin:password@ (UnknownHostException) migrated to:  
  https://admin:password@ ([https](https://admin:password@) result UnknownHostException).
* http://user:pass@localhost:8080 (UnknownHostException) migrated to:  
  https://user:pass@localhost:8080 ([https](https://user:pass@localhost:8080) result UnknownHostException).
* http://packages.cloudfoundry.org/debian (404) migrated to:  
  https://packages.cloudfoundry.org/debian ([https](https://packages.cloudfoundry.org/debian) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.jenkins-ci.org/releases/ migrated to:  
  https://repo.jenkins-ci.org/releases/ ([https](https://repo.jenkins-ci.org/releases/) result 200).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-milestone-local migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-release-local migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).
* http://repo.spring.io/libs-snapshot-local migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).